### PR TITLE
notes sidebar redesign 

### DIFF
--- a/.expo/settings.json
+++ b/.expo/settings.json
@@ -1,0 +1,8 @@
+{
+  "hostType": "tunnel",
+  "lanType": "ip",
+  "dev": true,
+  "minify": false,
+  "urlRandomness": null,
+  "https": false
+}

--- a/.expo/settings.json
+++ b/.expo/settings.json
@@ -1,8 +1,0 @@
-{
-  "hostType": "tunnel",
-  "lanType": "ip",
-  "dev": true,
-  "minify": false,
-  "urlRandomness": null,
-  "https": false
-}

--- a/components/NotesCard.vue
+++ b/components/NotesCard.vue
@@ -147,7 +147,7 @@
       </vs-avatar>
       <vs-tooltip>
       <vs-avatar class="icon-small">
-        <i class="bx bx-meteor"></i>
+        <i class="bx bx-show"></i>
         <template #badge>
           {{ note.views }}
         </template>
@@ -158,7 +158,7 @@
       </vs-tooltip>
 
       <vs-avatar class="icon-small">
-        <i class="bx bx-save"></i>
+        <i class="bx bx-bookmark"></i>
       </vs-avatar>
     </div>
   </VxCard>

--- a/components/NotesSidebar.vue
+++ b/components/NotesSidebar.vue
@@ -6,21 +6,28 @@
     class="rounded-md w-full notes-sidebar"
     style="z-index: 2; border-radius: 1rem; height: auto;"
   >
-    <template #logo>
-      <vs-button icon danger @click="open = false">
-        <i class="bx bx-x text-2xl" />
-      </vs-button>
-      <vs-button warn @click="toggleNotesModal(true)">
+    <div>
+      <div class="vx-row w-full justify-center p-4">
+
+        <vs-button danger @click="open = false" class="w-full close-menu">
+        <i class="bx bx-x text-4xl" />
         <div class="text-2xl font-ginger-b">
-          Posted Note &nbsp;
+          &nbsp;Close Menu
         </div>
-        <i class="bx bx-notepad text-4xl" />
+      </vs-button> 
+
+      <vs-button warn @click="toggleNotesModal(true)" class="w-full">
+        <i class="bx bxs-plus-square text-4xl" />
+        <div class="text-2xl font-ginger-b">
+          &nbsp; Post New Note 
+        </div>
       </vs-button>
-    </template>
-    <div class="sidebar-content p-6 pt-0 w-full">
-      <div class="text-xl font-bold w-full vx-row justify-center pb-2">
-        Filters
       </div>
+    </div>
+    <div class="sidebar-content p-6 pt-0 w-full">
+      <!-- <div class="text-xl font-bold w-full vx-row justify-center pb-2">
+        Filters
+      </div> -->
       
       <!-- <div
         class="w-full rounded mb-4"
@@ -69,13 +76,17 @@
         </div>
       </div> -->
 
-      <div
+      <!-- <div
         class="w-full rounded my-4"
         style="background-color: gray; height: 2px;"
-      />
-      <h6 class="font-bold mb-5">Subjects</h6>
+      /> -->
+      <!-- <h6 class="font-bold mb-5">Subjects</h6> -->
 
-      <div
+
+
+      <!-- <h6 class="font-bold mb-5">Subjects</h6> -->
+
+      <!-- <div
         class="my-2 ml-6 vx-row items-center border-solid cursor-pointer"
         @click="selectAllSubjects()"
       >
@@ -91,8 +102,10 @@
         <div class="font-bold truncate text-xl">
           All
         </div>
-      </div>
+      </div> -->
+      <div class="filter-options">
       <vs-sidebar-group
+      color="#9331e1"
         v-for="(subjectGroup, groupIndex) in subjectGroups"
         :key="groupIndex + 4"
       >
@@ -115,6 +128,7 @@
           :key="index"
         >
           <vs-checkbox
+            color="#4D7C8A"
             v-model="SubjectDict[subject.name]"
             @click="subjectClicked(subject.name)"
           >
@@ -125,14 +139,12 @@
           </vs-checkbox>
         </vs-sidebar-item>
       </vs-sidebar-group>
-      <div
-        class="w-full rounded my-4"
-        style="background-color: gray; height: 2px;"/>
+      </div>
 
         <vs-select
         label="Grade"
         filter
-        class="block mb-6 w-6 mt-6 w-full lg:w-1/2"
+        class="block mb-6 w-6 mt-6 w-full lg:w-1/2 sort-option"
         placeholder="Grade"
         v-model="gradeSelect"
       >
@@ -149,7 +161,7 @@
         <vs-select
         label="Sort By"
         filter
-        class="block mb-6 w-6 mt-6 w-full lg:w-1/2"
+        class="block mb-6 w-6 mt-6 w-full lg:w-1/2 sort-option"
         placeholder="Sort By"
         v-model="sortSelect"
       >
@@ -164,29 +176,25 @@
       </vs-select>
 
       <div class="vx-row w-full">
-        <div class="vx-col w-1/2 text-ginger" style="">
+        
+        
           <vs-button
-            class="text-3xl text-ginger-b p-2 w-full"
+            class="text-3xl text-ginger-b p-2 w-full filter-button"
             style="font-size: 1.25rem;"
             size="lg"
-            :active="false"
-            color="#808080"
-            border
+            color="#99b8d1"
             @click="clearFilter()"
-            >CLEAR</vs-button
+            >CLEAR FILTERS</vs-button
           >
-        </div>
 
-        <div class="vx-col w-1/2 text-ginger" style="">
           <vs-button
-            class="text-3xl text-ginger-b p-2 w-full"
+            class="text-3xl text-ginger-b p-2 w-full filter-button"
             style="font-size: 1.25rem;"
             size="lg"
-            color="success"
+            color="#b553ea"
             @click="filterSubjects()"
-            >GO</vs-button
+            >FILTER</vs-button
           >
-        </div>
       </div>
     </div>
   </vs-sidebar>
@@ -205,7 +213,6 @@ import {
   SubjectGroups,
   SortOptionsList,
   SortOptions_O
-  // SubjectGroupDict
 } from '~/types/subjects'
 
   let s: {
@@ -221,7 +228,7 @@ import {
     "Social Sciences" : false,
     Technology : false,
   }
-// huh.
+
 @Component<NotesSidebar>({ components: {} })
 export default class NotesSidebar extends Vue {
   GradeList = GradeList
@@ -262,7 +269,6 @@ export default class NotesSidebar extends Vue {
   SubjectDict = s;
   ActiveSubjectList :Subject_O[] = [];
 
-  // selectedSubjects = SubjectList.map()
   currentSubjects = NestedSubjectList.flatMap((value) =>
     value.items.map((v2) => v2.name)
   )
@@ -290,7 +296,7 @@ export default class NotesSidebar extends Vue {
       this.selectAllSubjects();
     }
     this.gradeSelect = 'ALL';
-    this.sortSelect = "upVotes";
+    this.sortSelect = "createdAt";
   }
   setFilter() {
     this.activeStars = this.hoverStars = this.filterStars
@@ -320,6 +326,11 @@ export default class NotesSidebar extends Vue {
   }
 
   async filterSubjects() {
+    if (this.ActiveSubjectList.length == 0) {
+        this.allSelected = false
+        this.selectAllSubjects();
+      }
+    console.log(this.ActiveSubjectList)
     const loading = this.$vs.loading()
     notesStore.SetActiveFilter({
       sortSelect : this.sortSelect,
@@ -347,5 +358,32 @@ export default class NotesSidebar extends Vue {
 }
 .open {
   transform: translate(0%);
+}
+// sidebar subject hover effect
+.vs-sidebar__item:hover {
+  padding-left: 30px !important;
+}
+.filter-options {
+  padding:0 10px !important;
+}
+.vs-sidebar__item__arrow {
+  margin-right: 50px !important;
+}
+.vs-sidebar__group__header {
+  margin-bottom: 3% !important;
+}
+.sort-option {
+  margin-top: 40px;
+}
+.filter-button {
+  letter-spacing: 0.1rem;
+}
+.close-menu {
+  display:none;
+}
+@media only screen and (max-width: 991px) {
+  .close-menu {
+  display:block;
+  }
 }
 </style>

--- a/components/NotesSidebar.vue
+++ b/components/NotesSidebar.vue
@@ -343,7 +343,7 @@ export default class NotesSidebar extends Vue {
   }
 
   get open() {
-    return !windowStore.isSmallScreen || windowStore.notesSidebarOpen
+    return !windowStore.smallerThanMd || windowStore.notesSidebarOpen
   }
 
   set open(open) {

--- a/pages/notes/index.vue
+++ b/pages/notes/index.vue
@@ -9,8 +9,8 @@
     <div id="notes-content-overlay"></div>
     <NotesSidebar />
     <div class="sidebar-spacer"></div>
-    <div class="vx-col lg:w-1/2 md:w-2/3 w-full sidebar-spacer-margin">
-      <div class="vx-col w-full inline-flex md:hidden" style="">
+    <div class="vx-col lg:w-1/2 md:w-2/3 w-full">
+      <div class="vx-col w-full inline-flex lg:hidden" style="">
         <div class="vx-row mb-4 w-full bg-white rounded-md p-2">
           <vs-avatar class="icon-small float-right" @click="openNotesSidebar()">
             <i class="bx bx-menu" style="font-size: 1.25rem;" />
@@ -138,7 +138,7 @@ export default class NotesPage extends Vue {
 <style lang="scss">
 #notes-screen-container {
   .sidebar-spacer {
-    width: calc(260px);
+    width: calc(130px);
     margin-left: 0;
   }
 

--- a/store/notes.ts
+++ b/store/notes.ts
@@ -45,7 +45,7 @@ export default class NotesModule extends VuexModule {
   ActiveGrade : Grade_O  = "ALL"
   ActiveSubjects: Subject_O[] = [...SubjectList]
   ActiveNotes: Note[] = []
-  SortSelect : SortOptions_O = "upVotes"
+  SortSelect : SortOptions_O = "createdAt"
 
   NotesPerPage = 5
   EndOfList = false

--- a/store/window.ts
+++ b/store/window.ts
@@ -79,6 +79,11 @@ export default class WindowModule extends VuexModule {
     {
         return this.windowWidth < 992;
     }
+    public get smallerThanMd()
+    {
+        return this.windowWidth < 1024;
+    }
+    
     
     public get isLargeScreen()
     {

--- a/types/subjects.ts
+++ b/types/subjects.ts
@@ -34,31 +34,31 @@ export const SubjectIconList :
     [index in Subject_O | SubjectGroup_O] : string;
 } = 
 {
-    Sciences : 'bxs-magic-wand',
-    Languages : 'bxl-audible',
+    Sciences : 'bx-bulb',
+    Languages : 'bx-pen',
     Arts : 'bx-palette',
-    "Social Sciences" : 'bx-group',
-    Technology : 'bx-laptop',
+    "Social Sciences" : 'bx-world',
+    Technology : 'bx-server',
 
     Math : 'bx-brain',
     'Physics' : 'bx-atom',
-    Chemistry : 'bx-bong',
-    Biology : 'bx-hive',
+    Chemistry : 'bxs-flask',
+    Biology : 'bx-dna',
     'English' : 'bx-book-bookmark',
-    French : 'bxs-map-alt',
-    'Spanish' : 'bx-church',
-    "Visual Arts" : 'bx-brush',
-    Music : 'bx-music',
+    French : 'bx-book',
+    'Spanish' : 'bx-bible',
+    "Visual Arts" : 'bxs-brush',
+    Music : 'bxs-music',
     Dance : 'bxs-guitar-amp',
-    Drama : 'bxs-user-voice',
+    Drama : 'bx-mask',
     Film : 'bx-camera-movie',
     TOK : 'bx-network-chart',
-    'Geography' : 'bx-landscape',
+    'Geography' : 'bx-globe',
     History : 'bxs-landmark',
     Business : 'bx-briefcase',
-    ICS : 'bx-terminal',
-    ITGS : 'bx-globe-alt',
-    ComTech : 'bx-message-rounded-edit'
+    ICS : 'bx-code-alt',
+    ITGS : 'bx-data',
+    ComTech : 'bxs-component'
 } as const;
 
 export interface SubjectItem {


### PR DESCRIPTION
# Notes Page Sidebar Redesign Changes:
1. Button styles changes (color and positioning)
2. Icons changes (for subjects)
3. "all" button removal
3. Fix of error when no fields are selected and user attempts to search
5. Change of default sort by option from up votes to recent
6. Only display close menu button on screens where width is < 991px

![2020-08-09 (1)](https://user-images.githubusercontent.com/44539091/89741367-b2d05480-da5e-11ea-86d1-0ecae9e70f74.png)
![2020-08-09 (2)](https://user-images.githubusercontent.com/44539091/89741372-bd8ae980-da5e-11ea-8f06-186506f23ca2.png)
![2020-08-09 (3)](https://user-images.githubusercontent.com/44539091/89741374-c085da00-da5e-11ea-96b0-1465250f8b1b.png)
![2020-08-09 (4)](https://user-images.githubusercontent.com/44539091/89741376-c24f9d80-da5e-11ea-9412-f2cdb55bc73a.png)
![2020-08-09 (5)](https://user-images.githubusercontent.com/44539091/89741378-c380ca80-da5e-11ea-9b04-5ac730d34bab.png)
![2020-08-09 (6)](https://user-images.githubusercontent.com/44539091/89741379-c7ace800-da5e-11ea-8bf4-3574e9294738.png)
![2020-08-09 (7)](https://user-images.githubusercontent.com/44539091/89741380-cb406f00-da5e-11ea-968b-d8a9ac4228c7.png)

  