### PR TITLE
Responsive notes

### DIFF
--- a/assets/scss/components/notes_md.scss
+++ b/assets/scss/components/notes_md.scss
@@ -1,0 +1,63 @@
+.md-container {
+    font-family: 'Quicksand', sans-serif !important;
+    word-wrap: break-word;
+  
+    img {
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+    }
+  
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-family: 'ginger-bold', 'Trebuchet MS', 'Lucida Sans Unicode',
+        'Lucida Grande', 'Lucida Sans', Arial, sans-serif !important;
+      font-weight: 200 !important;
+      margin-bottom: 2rem !important;
+    }
+    p {
+      margin-bottom: 2rem !important;
+      font-weight: 500 !important;
+    }
+  
+    blockquote {
+      margin-left: -10px !important;
+      padding-left: 23px !important;
+      box-shadow: rgb(41, 41, 41) 3px 0px 0px 0px inset !important;
+      p {
+        font-style: italic !important;
+      }
+    }
+    pre > code {
+      margin-bottom: 2rem !important;
+      background-color: #eeeeee;
+      border-radius: 0.5rem;
+      padding: 1rem;
+    }
+    ul,
+    ol {
+      li {
+        font-weight: 500 !important;
+      }
+      margin-left: 2rem;
+      margin-bottom: 1rem;
+      list-style-type: symbols();
+      p {
+        margin-bottom: 0.5rem !important;
+      }
+      ol {
+        list-style-type: lower-roman;
+      }
+  
+      ul,
+      ol {
+        ol {
+          list-style-type: lower-alpha;
+        }
+      }
+    }
+  }
+  

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -27,13 +27,16 @@
 // rtl
 @import "vuexy/rtl";
 
+// Custom components css
+@import "components/notes_md.scss";
+
 .content-popup {
   .vs-dialog--scroll .vs-dialog__content {
     max-height: calc(100vh - 200px);
   }
 
   .vs-dialog {
-    min-width: 40vw !important;
+    min-width: 60vw !important;
     min-height: 60vh !important;
   }
 }

--- a/components/NotesCard.vue
+++ b/components/NotesCard.vue
@@ -9,34 +9,34 @@
     <div class="vx-row w-full justify-between items-center">
       <!-- Profile Picture -->
       <div class="justify-start w-5/6 m-0">
-      <div class="vx-row w-full justify-start items-center">
-      <div class="vx-col">
-        <vs-tooltip class="inline-block">
-          <vs-avatar class="icon">
-            <img v-if="note.userPhotoUrl" :src="note.userPhotoUrl" />
-            <template #text v-else>
-              {{ note.userDisplayName }}
-            </template>
-          </vs-avatar>
-          <template #tooltip>
-            {{ note.userDisplayName }}
-          </template>
-        </vs-tooltip>
-      </div>
-      <div class="vx-col">
-      <!-- User name -->
-        <div class="text-xl text-ginger-b">
-          <div class="">
-            {{ note.userDisplayName }}
+        <div class="vx-row w-full justify-start items-center">
+          <div class="vx-col">
+            <vs-tooltip class="inline-block">
+              <vs-avatar class="icon">
+                <img v-if="note.userPhotoUrl" :src="note.userPhotoUrl" />
+                <template #text v-else>
+                  {{ note.userDisplayName }}
+                </template>
+              </vs-avatar>
+              <template #tooltip>
+                {{ note.userDisplayName }}
+              </template>
+            </vs-tooltip>
+          </div>
+          <div class="vx-col">
+            <!-- User name -->
+            <div class="text-xl text-ginger-b">
+              <div class="">
+                {{ note.userDisplayName }}
+              </div>
+            </div>
+            <div class="">
+              <div class="">
+                {{ note.createdAt.toLocaleString() }}
+              </div>
+            </div>
           </div>
         </div>
-        <div class="">
-          <div class="">
-            {{ note.createdAt.toLocaleString() }}
-          </div>
-        </div>
-      </div>
-      </div>
       </div>
 
       <!-- Action Button -->
@@ -48,29 +48,41 @@
     </div>
 
     <!-- Category Pills -->
-    <div class="w-4/5 vx-row p-2 items-center text-sm mt-2 ml-1/2 title-content">
-      <div class="rounded-full bg-orange-500 p-2 px-4 vx-row items-center text-ginger text-white">
+    <div
+      class="w-4/5 vx-row p-2 items-center text-sm mt-2 ml-1/2 title-content"
+    >
+      <div
+        class="rounded-full bg-orange-500 p-2 px-4 vx-row items-center text-ginger text-white"
+      >
         Grade {{ note.grade }}
       </div>
-      <div class="rounded-full bg-purple-500 p-2 px-4 vx-row items-center text-ginger text-white mx-2">
+      <div
+        class="rounded-full bg-purple-500 p-2 px-4 vx-row items-center text-ginger text-white mx-2"
+      >
         <i class="bx text-xl text-white mr-2" :class="getIcon(note.subject)" />
         {{ note.subject }}
       </div>
     </div>
 
     <!-- Title -->
-    <div class="w-4/5 text-ginger-b text-3xl p-4 ml-1/2 title-content" style="line-height: 1;">
+    <div
+      class="w-4/5 text-ginger-b text-3xl p-4 ml-1/2 title-content"
+      style="line-height: 1;"
+    >
       {{ note.title }}
     </div>
 
     <!-- Content -->
-    <div class="vx-row w-full justify-center p-4 pt-0 m-0 pt-0" style="margin: 0;">
+    <div
+      class="vx-row w-full justify-center p-4 pt-0 m-0 pt-0"
+      style="margin: 0;"
+    >
       <div
         class="md:w-4/5 w-full vx-row justify-center overflow-y-hidden relative rounded-md p-1"
         :style="
-          preview ? (hasImage ? 'max-height : 512px' : 'max-height: 200px') : ''"
+          preview ? (hasImage ? 'max-height : 512px' : 'max-height: 200px') : ''
+        "
       >
-      <div style="width:100%;height:100%;position:absolute;background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 80%, white 90%);"></div>
         <img
           :src="note.images[0]"
           class="responsive rounded border-solid mb-4"
@@ -107,8 +119,21 @@
         </vue-flux>
         <div
           v-html="$md.render(note.contents)"
-          class="w-full text-ginger p-2"
-        />
+          id="notes-md"
+          class="w-full text-ginger p-2 md-container"
+        ></div>
+        <!-- <div
+          style="
+            width: 100%;
+            height: 100%;
+            position: absolute;
+            background-image: linear-gradient(
+              to bottom,
+              rgba(0, 0, 0, 0) 80%,
+              white 90%
+            );
+          "
+        ></div> -->
       </div>
     </div>
 
@@ -132,15 +157,13 @@
         </template>
       </vs-avatar>
       <vs-tooltip>
-      <vs-avatar class="icon-small">
-        <i class="bx bx-show"></i>
-        <template #badge>
-          {{ note.views }}
-        </template>
-      </vs-avatar>
-      <template #tooltip>
-        {{ note.views }} Views
-      </template>
+        <vs-avatar class="icon-small">
+          <i class="bx bx-show"></i>
+          <template #badge>
+            {{ note.views }}
+          </template>
+        </vs-avatar>
+        <template #tooltip> {{ note.views }} Views </template>
       </vs-tooltip>
 
       <vs-avatar class="icon-small">
@@ -154,7 +177,7 @@
 import { Component, Vue, Prop } from 'nuxt-property-decorator'
 import { Note } from '~/types/notes'
 import { SubjectIconList, SubjectGroup_O, Subject_O } from '~/types/subjects'
-import {notesStore} from '~/store'
+import { notesStore } from '~/store'
 
 @Component<NotesCard>({
   // components :
@@ -174,20 +197,20 @@ export default class NotesCard extends Vue {
   getIcon(subject: SubjectGroup_O | Subject_O) {
     return SubjectIconList[subject]
   }
-  userLiked(id ?: string) {
-    if(!id) return false;
+  userLiked(id?: string) {
+    if (!id) return false
     return notesStore.likedPosts.includes(id)
   }
 
   async toggleLike(id?: string, time?: any) {
-    if(!id) return;
-    const a = this.$vs.loading();
+    if (!id) return
+    const a = this.$vs.loading()
     await notesStore.ToggleLikedNote(id)
     a.close()
   }
   vfOptions = {
     autoplay: false,
-    allowFullscreen: true,
+    allowFullscreen: true
   }
   vfTransitions = ['swipe']
   PushNotesPage() {
@@ -244,7 +267,7 @@ export default class NotesCard extends Vue {
 }
 @media only screen and (max-width: 768px) {
   .title-content {
-  margin-left: 0%;
+    margin-left: 0%;
   }
 }
 </style>

--- a/components/NotesCard.vue
+++ b/components/NotesCard.vue
@@ -188,7 +188,9 @@ import { notesStore } from '~/store'
       this.hasImage = true
     }
   }
-})
+}
+)
+
 export default class NotesCard extends Vue {
   @Prop({ required: true }) note!: Note
   @Prop({ default: false }) clickable!: boolean
@@ -269,5 +271,11 @@ export default class NotesCard extends Vue {
   .title-content {
     margin-left: 0%;
   }
+}
+.flux-image {
+  background-position: 0px 0px !important;
+  background-size:auto 100% !important;
+  background-color: black;
+  background-position: center !important;
 }
 </style>


### PR DESCRIPTION
# Changes made 

1. Images maintain aspect ratio in notes
2. Black bars added around images if they do not take up full screen
3. Images centered on slideshow

## Images

![image](https://user-images.githubusercontent.com/44539091/90162718-101c1c80-dd63-11ea-879d-75c3ff13e92b.png)
![image](https://user-images.githubusercontent.com/44539091/90162738-16aa9400-dd63-11ea-94d4-e979f9e5fd01.png)
![image](https://user-images.githubusercontent.com/44539091/90162749-19a58480-dd63-11ea-8718-1889cab3ed4a.png)
![image](https://user-images.githubusercontent.com/44539091/90162766-1f9b6580-dd63-11ea-9549-4707e1e774f7.png)
