### PR TITLE
responsive images in notes

### DIFF
--- a/components/NotesCard.vue
+++ b/components/NotesCard.vue
@@ -188,7 +188,9 @@ import { notesStore } from '~/store'
       this.hasImage = true
     }
   }
-})
+}
+)
+
 export default class NotesCard extends Vue {
   @Prop({ required: true }) note!: Note
   @Prop({ default: false }) clickable!: boolean
@@ -269,5 +271,11 @@ export default class NotesCard extends Vue {
   .title-content {
     margin-left: 0%;
   }
+}
+.flux-image {
+  background-position: 0px 0px !important;
+  background-size:auto 100% !important;
+  background-color: black;
+  background-position: center !important;
 }
 </style>


### PR DESCRIPTION
# Changes made 

1. Images maintain aspect ratio in notes
2. Black bars added around images if they do not take up full screen
3. Images centered on slideshow

## Images

![image](https://user-images.githubusercontent.com/44539091/90162718-101c1c80-dd63-11ea-879d-75c3ff13e92b.png)
![image](https://user-images.githubusercontent.com/44539091/90162738-16aa9400-dd63-11ea-94d4-e979f9e5fd01.png)
![image](https://user-images.githubusercontent.com/44539091/90162749-19a58480-dd63-11ea-8718-1889cab3ed4a.png)
![image](https://user-images.githubusercontent.com/44539091/90162766-1f9b6580-dd63-11ea-9549-4707e1e774f7.png)
