### PR TITLE
fix: redirect queries will persist through login

### DIFF
--- a/middleware/router-auth.ts
+++ b/middleware/router-auth.ts
@@ -8,7 +8,6 @@ export default function({store, redirect, route} : Context)
     if(route.name == "index" )
     {
         store.state.auth.user == null ? redirect("/splash") : redirect("/home");
-        // Redirect to either home or splash page
     }
 
     if(store.state.auth.user != null && (route.name == null || route?.name?.split('/').some(record => record == 'auth')))
@@ -17,7 +16,9 @@ export default function({store, redirect, route} : Context)
     }
     if(store.state.auth.user == null && (route.name == null || isAdminRoute(route)) && route.name != "auth/Login" && route.name!="auth/SignUp") 
     {
-        redirect('/auth/login')
+        const redirectPath = route.fullPath;
+        // Records the proper link
+        redirect(`/auth/login?redirect=${encodeURIComponent(redirectPath)}`)
     };
 }
 

--- a/mixins/AuthenticationMixin.ts
+++ b/mixins/AuthenticationMixin.ts
@@ -1,15 +1,34 @@
-import { Component, Vue } from 'nuxt-property-decorator'
+import { Component, Vue, Watch } from 'nuxt-property-decorator'
 import { authStore } from '~/store'
+import type {User, UserData} from '~/types/user'
 
 @Component
 export default class AuthenticationMixin extends Vue {
   errorMessage = ''
   errorCode: number | null = null
+  get AuthUser()
+  {
+    return authStore.user;
+  }
+
+  @Watch("AuthUser")
+  onAuthUserChange(val : User, oldVal : any)
+  {
+    // If Auth User changes and the user is valid, will automatically redirect to homepage
+    if(val)
+    {
+      if(val.emailVerified)
+      {
+        this.sendToHome();
+      }
+    }
+  }
 
   get validEmail() {
     return (email: string) =>
       /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(email)
   }
+
   get error()
   {
     return this.errorMessage;
@@ -32,11 +51,19 @@ export default class AuthenticationMixin extends Vue {
   {
     setTimeout(() => {
       loading.close();
-      this.$router.push('/home');
+      this.sendToHome();
     }, 500)
   }
 
-  async LoginGoogle() {
+  sendToHome()
+  {
+    // Will redirect to the proper link, not just home every single time
+    const redirectPath = (typeof this.$route.query.redirect === "string") ? decodeURIComponent(this.$route.query.redirect) : "/home"; 
+    this.$router.push(redirectPath);
+  }
+
+  async LoginGoogle() 
+  {
     const loading = this.$vs.loading()
     this.resetError()
     try {

--- a/static/firebase-auth-sw.js
+++ b/static/firebase-auth-sw.js
@@ -6,7 +6,7 @@ importScripts(
 importScripts(
   'https://www.gstatic.com/firebasejs/7.17.1/firebase-auth.js'
 )
-firebase.initializeApp({"apiKey":"AIzaSyDSQxtPPZA9QH8iExKXhMFPl-YQunI2rl0","authDomain":"supplant-44e15.firebaseapp.com","databaseURL":"https:\u002F\u002Fsupplant-44e15.firebaseio.com","projectId":"supplant-44e15","storageBucket":"supplant-44e15.appspot.com","messagingSenderId":"164745116317","appId":"1:164745116317:web:9818b7748fa0bac68c3274","measurementId":"G-ZSN4CNQTNF"})
+firebase.initializeApp({"apiKey":"AIzaSyDSQxtPPZA9QH8iExKXhMFPl-YQunI2rl0","authDomain":"supplant-44e15.firebaseapp.com","databaseURL":"https:\u002F\u002Fsupplant-44e15.firebaseio.com","projectId":"supplant-44e15","storageBucket":"supplant-44e15.appspot.com","messagingSenderId":"164745116317","appId":"1:164745116317:web:9818b7748fa0bac68c3274","measurementId":"G-EPMZNE5SS1"})
 
 /**
  * Returns a promise that resolves with an ID token if available.


### PR DESCRIPTION
Before, if you weren't logged in and tried to go to a specific question, lets say `questions/gQpydF1OiEVTMLeuEipq`, the middleware would intercept you, send you to `/auth/login`, and after you logged in, it would always send you to `/home` and not your intended route. Fixed that.

Also, if the auth happened to update in the middle of the page load, for example on local host, it would always keep you at `/login` even if you are already logged in. Now, if the auth state changes when the page is loaded, it will auto redirect you properly again.