### PR TITLE
refactor: use 1 total exp stat for read/write efficiency

### DIFF
--- a/pages/user/profile.vue
+++ b/pages/user/profile.vue
@@ -207,11 +207,11 @@ export default class UserProfile extends mixins(UserMixin) {
   }
 
   get userLevel() {
-    return this.UserData?.progressionLevel || 0
+    return Math.floor((this.UserData?.totalExp || 0) / 200)
   }
 
   get userExp() {
-    const userExp = (this.UserData?.progressionExp || 0) / 2 // 200 exp points per level, its in percentage so multiply by 100.
+    const userExp = ((this.UserData?.totalExp || 0) % 200) / 2 // 200 exp points per level, its in percentage so multiply by 100.
     return userExp
   }
 

--- a/pages/user/view/_id.vue
+++ b/pages/user/view/_id.vue
@@ -29,7 +29,7 @@
               <div class="vx-row w-full my-2 items-center">
                 <div class="font-bold text-xl mr-2 text-green">Level</div>
                 <vs-avatar warn size="25">
-                  <div class="font-bold text-base">{{ userInfo.progressionLevel }}</div>
+                  <div class="font-bold text-base">{{ userLevel }}</div>
                 </vs-avatar>
               </div>
 
@@ -208,11 +208,11 @@ export default class UserPage extends Vue {
   }
 
   get userLevel() {
-    return this.userInfo?.progressionLevel || 0
+    return Math.floor((this.userInfo?.totalExp || 0) / 200)
   }
 
   get userExp() {
-    const userExp = (this.userInfo?.progressionExp || 0) / 2 // 200 exp points per level, its in percentage so multiply by 100.
+    const userExp = ((this.userInfo?.totalExp || 0) % 200) / 2 // 200 exp points per level, its in percentage so multiply by 100.
     return userExp
   }
 

--- a/types/user.ts
+++ b/types/user.ts
@@ -38,6 +38,7 @@ export interface UserData {
   newsletter?: boolean
   progressionExp?: number
   progressionLevel?: number
+  totalExp : number;
 
   discordId?: string
   discordUsername?: string


### PR DESCRIPTION
instead of using both `progressionLevel` and `progressionExp` which requires extra reads and writes to keep updated, just use one single `totalExp`, from which the level and current level exp can be calculated on the client