### PR TITLE
Issue #225 Fix - Darken background colours around subjects in profile so text is easier to read

### DIFF
--- a/pages/user/profile.vue
+++ b/pages/user/profile.vue
@@ -208,7 +208,7 @@ export default class UserProfile extends mixins(UserMixin) {
   
   cmyk(color : number) {
     const minBlack = 10;
-    const maxBlack = 90;
+    const maxBlack = 50;
     return 255 * (1 - (color / 100)) * (1 - (Math.floor(Math.random() * (maxBlack - minBlack)) + minBlack) / 100)
   }
   

--- a/pages/user/profile.vue
+++ b/pages/user/profile.vue
@@ -65,7 +65,7 @@
             <div class="w-full vx-row p-2 items-center text-sm">
               <div
                 class="rounded-full px-4 py-2 vx-row items-center text-ginger text-white mx-2 my-1"
-                :style="`background-color: #${randomColor()}`"
+                :style="`background-color: ${randomColor()}`"
                 v-for="(subject, index) in UserData.interestedSubjects"
                 :key="index"
               >
@@ -205,8 +205,15 @@ export default class UserProfile extends mixins(UserMixin) {
   getIcon(subject: SubjectGroup_O | Subject_O) {
     return SubjectIconList[subject]
   }
+  
+  cmyk(color : number) {
+    const minBlack = 10;
+    const maxBlack = 90;
+    return 255 * (1 - (color / 100)) * (1 - (Math.floor(Math.random() * (maxBlack - minBlack)) + minBlack) / 100)
+  }
+  
   randomColor() {
-    return Math.floor(Math.random() * 16777215).toString(16)
+    return "rgb(" + this.cmyk(Math.floor(Math.random() * 100)).toString() + ", " + this.cmyk(Math.floor(Math.random() * 100)).toString() + ", " + this.cmyk(Math.floor(Math.random() * 100)).toString() + ")"
   }
 }
 </script>


### PR DESCRIPTION
Changed function randomColor() so that it uses Cyan-Magenta-Yellow-Black colouring which allows for better control over colour darkness compared to hexadecimal format.
Added function cmyk() to convert from cymk format (which is not supported by css) to rgb. The function allows for control over minimum and maximum black.
