### PR TITLE
feat: personalized notes feed without int firebase reads

### DIFF
--- a/pages/notes/index.vue
+++ b/pages/notes/index.vue
@@ -62,7 +62,7 @@ import { School_O } from '~/types/schools'
       type: 'circles',
       text : "Loading Data"
     })
-    const notes = notesStore.GetMoreNotes(5)
+    const notes = notesStore.GetMoreNotes(true)
     await Promise.all([notes])
     this.loaded = true;
     loading.close()
@@ -79,13 +79,13 @@ export default class NotesPage extends mixins(LoadScroll) {
 
   async filter() {
     const loading = this.$vs.loading()
-    notesStore.SET_FILTER({
+    notesStore.SetFilter({
       sortSelect: this.sort,
       filterSubjects: this.subjects,
       filterGrades: this.grade,
       filterSchools: this.school
     })
-    await notesStore.GetMoreNotes()
+    await notesStore.GetMoreNotes(true)
     loading.close()
   }
   @Watch('IsScrolledDown')

--- a/pages/notes/index.vue
+++ b/pages/notes/index.vue
@@ -59,7 +59,8 @@ import { School_O } from '~/types/schools'
   components: { NotesCard, FilterSidebar },
   async mounted() {
     const loading = this.$vs.loading({
-          type: 'waves',
+      type: 'circles',
+      text : "Loading Data"
     })
     const notes = notesStore.GetMoreNotes(5)
     await Promise.all([notes])

--- a/pages/notes/index.vue
+++ b/pages/notes/index.vue
@@ -19,7 +19,7 @@
     </FilterSidebar>
     <div class="sidebar-spacer"></div>
     <div class="vx-col lg:w-2/3 md:w-2/3 w-full">
-      <div class="vx-col w-full inline-flex lg:hidden" style="">
+      <div class="vx-col w-full inline-flex lg:hidden" style>
         <div class="vx-row mb-4 w-full bg-white rounded-md p-2">
           <vs-avatar class="icon-small float-right" @click="openFilterSidebar()">
             <i class="bx bx-menu" style="font-size: 1.25rem;" />
@@ -62,8 +62,17 @@ import { School_O } from '~/types/schools'
       type: 'circles',
       text : "Loading Data"
     })
-    const notes = notesStore.GetMoreNotes(true)
-    await Promise.all([notes])
+    try {
+      const notes = notesStore.GetMoreNotes(true)
+      await Promise.all([notes])
+    } catch (error)
+    {
+      console.error({error});
+      this.$vs.notification({
+        title : error.message,
+        color : "danger"
+      })
+    }
     this.loaded = true;
     loading.close()
   }

--- a/pages/notes/index.vue
+++ b/pages/notes/index.vue
@@ -58,10 +58,12 @@ import { School_O } from '~/types/schools'
 @Component<NotesPage>({
   components: { NotesCard, FilterSidebar },
   async mounted() {
-    const loading = this.$vs.loading()
-    this.loaded = true;
+    const loading = this.$vs.loading({
+          type: 'waves',
+    })
     const notes = notesStore.GetMoreNotes(5)
     await Promise.all([notes])
+    this.loaded = true;
     loading.close()
   }
 })

--- a/store/moduleTemplate.ts
+++ b/store/moduleTemplate.ts
@@ -1,6 +1,5 @@
 import { Module, VuexModule, Action, Mutation } from 'vuex-module-decorators'
 import firestore from '~/plugins/firestore'
-import { firestore as FirestoreModule } from 'firebase/app'
 
 @Module({ stateFactory: true, name: 'template', namespaced: true })
 export default class TemplateModule extends VuexModule {

--- a/store/notes.ts
+++ b/store/notes.ts
@@ -176,12 +176,6 @@ export default class NotesModule extends VuexModule {
     if (this.EndOfList) {
       return
     }
-    console.log(
-      this.ActiveGrade,
-      this.ActiveSchool,
-      this.ActiveSubjects,
-      this.SortSelect
-    )
     if (
       this.ActiveGrade === 'ALL' &&
       this.ActiveSchool === 'All Schools' &&
@@ -189,7 +183,7 @@ export default class NotesModule extends VuexModule {
       this.SortSelect === 'magicRank'
     ) {
       console.log('CUSTOM RANK')
-      if (!LastVisible && authStore.userData?.lastFeedUpdated && HourDiff(authStore.userData.lastFeedUpdated) > 2) {
+      if (!LastVisible && (!authStore.userData?.lastFeedUpdated || HourDiff(authStore.userData.lastFeedUpdated) > 2)) {
         await functions.httpsCallable('PersonalRank')()
       }
       let query: store.Query<store.DocumentData> = firestore.collectionGroup(

--- a/store/questions.ts
+++ b/store/questions.ts
@@ -1,6 +1,6 @@
 import { Module, VuexModule, Action, Mutation } from 'vuex-module-decorators'
 import firestore from '~/plugins/firestore'
-import { auth, firestore as FirestoreModule } from 'firebase/app'
+import { firestore as FirestoreModule } from 'firebase/app'
 import functions from '~/plugins/firebaseFunctions'
 import storage from '~/plugins/firebaseStorage'
 
@@ -16,9 +16,8 @@ import {
 
 import { authStore } from '~/store'
 import { School_O } from '~/types/schools'
-import { firestore as store } from 'firebase/app'
 
-let LastVisible: store.QueryDocumentSnapshot<store.DocumentData> | null = null
+let LastVisible: FirestoreModule.QueryDocumentSnapshot<FirestoreModule.DocumentData> | null = null
 
 @Module({ stateFactory: true, name: 'questions', namespaced: true })
 export default class QuestionsModule extends VuexModule {
@@ -104,7 +103,7 @@ export default class QuestionsModule extends VuexModule {
       return
     }
     if (max && max <= this.ActiveItems.length) return;
-    let query: store.Query<store.DocumentData> = firestore.collection('questions')
+    let query: FirestoreModule.Query<FirestoreModule.DocumentData> = firestore.collection('questions')
     // Do query filtering things
 
     if ((this.ActiveGrade !== 'ALL')) {

--- a/store/userGuide.ts
+++ b/store/userGuide.ts
@@ -1,6 +1,5 @@
 import { Module, VuexModule, Action, Mutation } from 'vuex-module-decorators'
 import firestore from '~/plugins/firestore'
-import { firestore as FirestoreModule } from 'firebase/app'
 import { authStore } from '~/store'
 import { Grade_O, Subject_O } from '~/types/subjects'
 import { School_O } from '~/types/schools'

--- a/types/env.utils.ts
+++ b/types/env.utils.ts
@@ -1,0 +1,4 @@
+import {firestore} from 'firebase/app'
+
+export const Timestamp = firestore.Timestamp
+export type Timestamp = firestore.Timestamp

--- a/types/notes.ts
+++ b/types/notes.ts
@@ -7,6 +7,7 @@ import {
   algoliaDate,
 } from './firebaseTypes'
 import { firestore } from 'firebase/app'
+
 import {School_O} from './schools'
 
 export interface Note_t {

--- a/types/notes.ts
+++ b/types/notes.ts
@@ -6,9 +6,9 @@ import {
   StoredImage,
   algoliaDate,
 } from './firebaseTypes'
-import { firestore } from 'firebase/app'
 
 import {School_O} from './schools'
+import { Timestamp } from './env.utils'
 
 export interface Note_t {
   title: string
@@ -69,7 +69,7 @@ export class Note {
   }
 
   static toFirebase = (note: Note): Note_t_F => {
-    const createdAt = firestore.Timestamp.fromDate(note.createdAt)
+    const createdAt = Timestamp.fromDate(note.createdAt)
     const { id, ...firebaseDoc } = { ...note }
     return { ...firebaseDoc, createdAt }
   }

--- a/types/user.ts
+++ b/types/user.ts
@@ -2,6 +2,7 @@ import { Grade_O, Subject_O } from './subjects'
 
 import { School_O } from './schools'
 import type firebase from '~/plugins/firebase'
+import { Timestamp } from './env.utils'
 
 export type User = {
   uid: string
@@ -46,5 +47,5 @@ export interface UserData {
   photoFileName?: string | null
 
   notifications?: boolean
-  lastFeedUpdated ?: firebase.firestore.Timestamp
+  lastFeedUpdated ?: Timestamp
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,6 +1,7 @@
 import { Grade_O, Subject_O } from './subjects'
 
 import { School_O } from './schools'
+import { firestore } from 'firebase'
 
 export type User = {
   uid: string
@@ -45,4 +46,5 @@ export interface UserData {
   photoFileName?: string | null
 
   notifications?: boolean
+  lastFeedUpdated ?: firestore.Timestamp
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,7 +1,7 @@
 import { Grade_O, Subject_O } from './subjects'
 
 import { School_O } from './schools'
-import { firestore } from 'firebase'
+import type firebase from '~/plugins/firebase'
 
 export type User = {
   uid: string
@@ -46,5 +46,5 @@ export interface UserData {
   photoFileName?: string | null
 
   notifications?: boolean
-  lastFeedUpdated ?: firestore.Timestamp
+  lastFeedUpdated ?: firebase.firestore.Timestamp
 }

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,4 +1,4 @@
-import { firestore } from 'firebase';
+import { firestore } from 'firebase/app';
 
 export const HourDiff = (date: firestore.Timestamp) => {
   const now = firestore.Timestamp.now().toDate();

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,7 +1,7 @@
-import { firestore } from 'firebase/app';
+import { Timestamp } from '~/types/env.utils';
 
-export const HourDiff = (date: firestore.Timestamp) => {
-  const now = firestore.Timestamp.now().toDate();
+export const HourDiff = (date: Timestamp) => {
+  const now = Timestamp.now().toDate();
   const Difference_In_Time = now.getTime() - date.toDate().getTime();
   const DifferenceInHours = Difference_In_Time / (1000 * 3600);
   return DifferenceInHours;

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,0 +1,8 @@
+import { firestore } from 'firebase';
+
+export const HourDiff = (date: firestore.Timestamp) => {
+  const now = firestore.Timestamp.now().toDate();
+  const Difference_In_Time = now.getTime() - date.toDate().getTime();
+  const DifferenceInHours = Difference_In_Time / (1000 * 3600);
+  return DifferenceInHours;
+};


### PR DESCRIPTION
YEEEEEEEEEEEEEEEEEE FINALLY HOLY CRAP THIS WAS SO MUCH ALGORITHM GRIND HOLY
Notes feed is now individually personalized, first load on the notes feed might take longer but refreshes should be fast
This is my feed, compare it to yours - 
![image](https://user-images.githubusercontent.com/46302202/92262675-82d37000-eea9-11ea-88db-28e9368ab522.png)
Implements #264 , #304 