### PR TITLE
goes back to first modal on button click in groups create/join

### DIFF
--- a/screens/groups/NewGroupsModal.vue
+++ b/screens/groups/NewGroupsModal.vue
@@ -63,12 +63,18 @@ export default class GroupsModal extends mixins(ValidateImage, PasteImage) {
     this.screen = args
     this.active = true
   }
+  @Watch('active')
+  setModal(){
+    this.screen = 0
+  }
+  
+
   get currentScreen() {
+    console.log(this.screen);
     return this.screens[this.screen]
   }
   screens = [GroupSelectModal, GroupCreateModal, GroupJoinModal]
   screen = 0
-
   schoolSelect: School_O | 'All Schools' = 'All Schools'
   characterLimit = 5000
   description = ''


### PR DESCRIPTION
When the create /join modal is closed, it will now automatically go back to the first page when reopnened (the screen where you can choose to create or join a group)
